### PR TITLE
encoding name in setFrom()

### DIFF
--- a/src/main/scala/play/api/libs/mailer/MailerPlugin.scala
+++ b/src/main/scala/play/api/libs/mailer/MailerPlugin.scala
@@ -183,7 +183,7 @@ abstract class CommonsMailer(smtpHost: String, smtpPort: Int,
   def createEmail(data: Email): MultiPartEmail = {
     val email = createEmail(data.bodyText, data.bodyHtml, data.charset.getOrElse("utf-8"))
     email.setSubject(data.subject)
-    email.setFrom(data.from)
+    setAddress(data.from) { (address, name) => email.setFrom(address, name) }
     data.replyTo.foreach(setAddress(_) { (address, name) => email.addReplyTo(address, name)})
     data.bounceAddress.foreach(email.setBounceAddress)
     data.to.foreach(setAddress(_) { (address, name) => email.addTo(address, name)})

--- a/src/test/scala/play/api/libs/mailer/MailerPluginSpec.scala
+++ b/src/test/scala/play/api/libs/mailer/MailerPluginSpec.scala
@@ -137,6 +137,44 @@ class MailerPluginSpec extends Specification {
       attachmentPart.getDescription mustEqual "A beautiful icon"
       attachmentPart.getDisposition mustEqual Part.INLINE
     }
+
+    "set address with name" in {
+      val mailer = MockCommonsMailer
+      val email = mailer.createEmail(Email(
+        subject = "Subject",
+        from = "James Roper <jroper@typesafe.com>",
+        to = Seq("Guillaume Grossetie <ggrossetie@localhost.com>"),
+        cc = Seq("Guillaume Grossetie <ggrossetie@localhost.com>"),
+        bcc = Seq("Guillaume Grossetie <ggrossetie@localhost.com>")
+      ))
+      email.getFromAddress.getAddress mustEqual "jroper@typesafe.com"
+      email.getFromAddress.getPersonal mustEqual "James Roper"
+      email.getToAddresses.get(0).getAddress mustEqual "ggrossetie@localhost.com"
+      email.getToAddresses.get(0).getPersonal mustEqual "Guillaume Grossetie"
+      email.getCcAddresses.get(0).getAddress mustEqual "ggrossetie@localhost.com"
+      email.getCcAddresses.get(0).getPersonal mustEqual "Guillaume Grossetie"
+      email.getBccAddresses.get(0).getAddress mustEqual "ggrossetie@localhost.com"
+      email.getBccAddresses.get(0).getPersonal mustEqual "Guillaume Grossetie"
+    }
+
+    "set address without name" in {
+      val mailer = MockCommonsMailer
+      val email = mailer.createEmail(Email(
+        subject = "Subject",
+        from = "jroper@typesafe.com",
+        to = Seq("<ggrossetie@localhost.com>"),
+        cc = Seq("ggrossetie@localhost.com"),
+        bcc = Seq("ggrossetie@localhost.com")
+      ))
+      email.getFromAddress.getAddress mustEqual "jroper@typesafe.com"
+      email.getFromAddress.getPersonal must beNull
+      email.getToAddresses.get(0).getAddress mustEqual "ggrossetie@localhost.com"
+      email.getToAddresses.get(0).getPersonal must beNull
+      email.getCcAddresses.get(0).getAddress mustEqual "ggrossetie@localhost.com"
+      email.getCcAddresses.get(0).getPersonal must beNull
+      email.getBccAddresses.get(0).getAddress mustEqual "ggrossetie@localhost.com"
+      email.getBccAddresses.get(0).getPersonal must beNull
+    }
   }
 
   "The MailerAPI" should {


### PR DESCRIPTION
Solution with lack of coding of a name of the sender.
In more detail here - https://github.com/playframework/play-mailer/issues/27