### PR TITLE
Add deprecated configuration to avoid ConfigException

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -19,3 +19,20 @@ play {
     connectiontimeout = null
   }
 }
+// Deprecated configuration
+smtp {
+  host = null
+  port = 25
+  ssl = no
+  tls = no
+  user = null
+  password = null
+  // Defaults to no, to take effect you also need to set the log level to "DEBUG" for the application logger
+  debug = no
+  // Defaults to no, will only log all the email properties instead of sending an email
+  mock = no
+  // Set the socket I/O timeout value in milliseconds. Default is 60 second timeout.
+  timeout = null
+  // Set the socket connection timeout value in milliseconds. Default is a 60 second timeout.
+  connectiontimeout = null
+}


### PR DESCRIPTION
When using the deprecated configuration `smtp`, the following exception is thrown if `smtp` is not defined in `reference.conf`:

```
Caused by: com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'mock'
	at com.typesafe.config.impl.SimpleConfig.findKeyOrNull(SimpleConfig.java:152) ~[config-1.3.0.jar:na]
	at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:170) ~[config-1.3.0.jar:na]
	at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:193) ~[config-1.3.0.jar:na]
	at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:198) ~[config-1.3.0.jar:na]
	at com.typesafe.config.impl.SimpleConfig.getIsNull(SimpleConfig.java:208) ~[config-1.3.0.jar:na]
	at play.api.PlayConfig.getOptional(Configuration.scala:951) ~[play_2.11-2.4.0-RC3.jar:2.4.0-RC3]
	at play.api.libs.mailer.CommonsMailer.mock$lzycompute(MailerPlugin.scala:86) ~[play-mailer_2.11.jar:3.0.0-SNAPSHOT]
	at play.api.libs.mailer.CommonsMailer.mock(MailerPlugin.scala:86) ~[play-mailer_2.11.jar:3.0.0-SNAPSHOT]
	at play.api.libs.mailer.CommonsMailer.instance$lzycompute(MailerPlugin.scala:89) ~[play-mailer_2.11.jar:3.0.0-SNAPSHOT]
	at play.api.libs.mailer.CommonsMailer.instance(MailerPlugin.scala:88) ~[play-mailer_2.11.jar:3.0.0-SNAPSHOT]
```