### PR TITLE
Immutable mailer instance

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,9 @@
 # About
 :next-branch-uri: https://github.com/playframework/play-mailer/tree/next
+:playframework-24x-docs-uri: https://www.playframework.com/documentation/2.4.x/
+:runtime-di-uri: {playframework-24x-docs-uri}/ScalaDependencyInjection
+:compile-time-di-uri: {playframework-24x-docs-uri}/ScalaCompileTimeDependencyInjection
+
 This plugin provides a simple emailer.
 
 //ifdef::env-github[]
@@ -35,7 +39,7 @@ play.mailer {
 }
 ```
 
-You can also configure the mailer programmatically, see below.
+You can also configure the mailer programmatically, see https://github.com/playframework/play-mailer/blob/master/user-manual.adoc[user manual].
 
 ## Usage
 
@@ -63,11 +67,7 @@ public class MyComponent {
       // sends text, HTML or both...
       .setBodyText("A text message")
       .setBodyHtml("<html><body><p>An <b>html</b> message</p></body></html>");
-    // configures the mailer before sending the email
-    Map<String, Object> conf = new HashMap<>();
-    conf.put("host", "typesafe.org");
-    conf.put("port", 1234);
-    mailerClient.configure(new Configuration(conf)).send(email);
+    mailerClient.send(email);
   }
 }
 ```
@@ -77,6 +77,10 @@ public class MyComponent {
 You need a `MailerClient` instance to send an email :
 
 ```scala
+import play.api.libs.mailer._
+import java.io.File
+import org.apache.commons.mail.EmailAttachment
+
 def sendEmail {
   val email = Email(
     "Simple email",
@@ -92,12 +96,11 @@ def sendEmail {
     bodyText = Some("A text message"),
     bodyHtml = Some("<html><body><p>An <b>html</b> message</p></body></html>")
   )
-  // configures the mailer before sending the email
-  mailerClient.configure(Configuration.from(Map("host" -> "typesafe.org", "port" -> 1234))).send(email)
+  mailerClient.send(email)
 }
 ```
 
-Since Play 2.4, you can use runtime dependency injection or compile time dependency injection.
+Since Play 2.4, you can use {runtime-di-uri}[runtime dependency injection] or {compile-time-di-uri}[compile time dependency injection].
 As a result, the `MailerClient` instance can be obtained using runtime dependency injection or compile time dependency injection.
 
 #### With runtime injection
@@ -105,7 +108,10 @@ As a result, the `MailerClient` instance can be obtained using runtime dependenc
 Use the `@Inject` annotation on the constructor of your component or controller:
 
 ```scala
-class MyComponent @Inject() (mailerClient: MailerClient) 
+import play.api.libs.mailer._
+import javax.inject.Inject
+
+class MyComponent @Inject() (mailerClient: MailerClient)
 ```
 
 #### With compile time injection
@@ -113,6 +119,8 @@ class MyComponent @Inject() (mailerClient: MailerClient)
 Declare the `MailerClient` without the `@Inject` annotation:
 
 ```scala
+import play.api.libs.mailer._
+
 class MyComponent(mailerClient: MailerClient)
 ```
 

--- a/samples/runtimeDI/app/controllers/ApplicationJava.java
+++ b/samples/runtimeDI/app/controllers/ApplicationJava.java
@@ -1,7 +1,6 @@
 package controllers;
 
 import org.apache.commons.mail.EmailAttachment;
-import play.Configuration;
 import play.Play;
 import play.api.libs.mailer.MailerClient;
 import play.libs.mailer.Email;
@@ -10,8 +9,6 @@ import play.mvc.Result;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ApplicationJava extends Controller {
 
@@ -32,18 +29,6 @@ public class ApplicationJava extends Controller {
       .setBodyText("A text message")
       .setBodyHtml("<html><body><p>An <b>html</b> message</p></body></html>");
     String id = mailer.send(email);
-    return ok("Email " + id + " sent!");
-  }
-
-  public Result configureAndSend() {
-    final Email email = new Email()
-      .setSubject("Simple email")
-      .setFrom("from@email.com")
-      .addTo("to@email.com");
-    Map<String, Object> conf = new HashMap<>();
-    conf.put("host", "typesafe.org");
-    conf.put("port", 1234);
-    String id = mailer.configure(new Configuration(conf)).send(email);
     return ok("Email " + id + " sent!");
   }
 }

--- a/samples/runtimeDI/app/controllers/ApplicationScala.scala
+++ b/samples/runtimeDI/app/controllers/ApplicationScala.scala
@@ -4,7 +4,6 @@ import java.io.File
 import javax.inject.Inject
 
 import org.apache.commons.mail.EmailAttachment
-import play.api.Configuration
 import play.api.Play.current
 import play.api.libs.mailer._
 import play.api.mvc.{Action, Controller}
@@ -27,9 +26,9 @@ class ApplicationScala @Inject()(mailer: MailerClient) extends Controller {
     Ok(s"Email $id sent!")
   }
 
-  def configureAndSend = Action {
-    val email = Email("Simple email", "from@email.com", Seq("to@email.com"))
-    val id = mailer.configure(Configuration.from(Map("host" -> "typesafe.org", "port" -> 1234))).send(email)
+  def sendWithCustomMailer = Action {
+    val mailer = new SMTPMailer(SMTPConfiguration("typesafe.org", 1234))
+    val id = mailer.send(Email("Simple email", "Mister FROM <from@email.com>"))
     Ok(s"Email $id sent!")
   }
 }

--- a/samples/runtimeDI/app/controllers/CustomSMTPConfigurationProvider.scala
+++ b/samples/runtimeDI/app/controllers/CustomSMTPConfigurationProvider.scala
@@ -1,0 +1,17 @@
+package controllers
+
+import javax.inject.Provider
+
+import play.api.libs.mailer.SMTPConfiguration
+import play.api.{Configuration, Environment}
+import play.api.inject.Module
+
+class CustomSMTPConfigurationProvider extends Provider[SMTPConfiguration] {
+  override def get() = new SMTPConfiguration("typesafe.org", 1234)
+}
+
+class CustomMailerConfigurationModule extends Module {
+  def bindings(environment: Environment, configuration: Configuration) = Seq(
+    bind[SMTPConfiguration].toProvider[CustomSMTPConfigurationProvider]
+  )
+}

--- a/samples/runtimeDI/conf/application.conf
+++ b/samples/runtimeDI/conf/application.conf
@@ -32,3 +32,9 @@ logger.application=DEBUG
 #  debug=false
 #  mock=false
 #}
+#play {
+#  modules {
+#    disabled += "play.api.libs.mailer.SMTPConfigurationModule"
+#    enabled += "controllers.CustomMailerConfigurationModule"
+#  }
+#}

--- a/samples/runtimeDI/conf/routes
+++ b/samples/runtimeDI/conf/routes
@@ -2,8 +2,7 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET        /send/java                     controllers.ApplicationJava.send()
-GET        /send/scala                    controllers.ApplicationScala.send()
+GET        /send/java                      controllers.ApplicationJava.send()
+GET        /send/scala                     controllers.ApplicationScala.send()
 
-GET        /configureAndSend/java         controllers.ApplicationJava.configureAndSend()
-GET        /configureAndSend/scala        controllers.ApplicationScala.configureAndSend()
+GET        /send/scala/customMailer        controllers.ApplicationScala.sendWithCustomMailer()

--- a/src/main/java/play/libs/mailer/MailerClient.java
+++ b/src/main/java/play/libs/mailer/MailerClient.java
@@ -14,12 +14,4 @@ public interface MailerClient {
    * @return The message id.
    */
   String send(Email email);
-
-  /**
-   * Configure the underlying instance of mailer
-   *
-   * @param configuration The configuration
-   * @return The mailer client
-   */
-  MailerClient configure(Configuration configuration);
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 play {
   modules {
     enabled += "play.api.libs.mailer.MailerModule"
+    enabled += "play.api.libs.mailer.SMTPConfigurationModule"
   }
   mailer {
     host = null

--- a/src/main/scala/play/api/libs/mailer/MailerPlugin.scala
+++ b/src/main/scala/play/api/libs/mailer/MailerPlugin.scala
@@ -201,18 +201,18 @@ abstract class SMTPMailer(defaultConfig: PlayConfig, var config: Option[SMTPConf
    */
   private def createEmail(bodyText: Option[String], bodyHtml: Option[String], charset: String): MultiPartEmail = {
     (bodyHtml.filter(_.trim.nonEmpty), bodyText.filter(_.trim.nonEmpty)) match {
-      case (Some(bodyHtml), bodyTextOpt) =>
+      case (Some(htmlMsg), bodyTextOpt) =>
         val htmlEmail = createHtmlEmail()
         htmlEmail.setCharset(charset)
-        htmlEmail.setHtmlMsg(bodyHtml)
+        htmlEmail.setHtmlMsg(htmlMsg)
         bodyTextOpt.foreach { bodyText =>
           htmlEmail.setTextMsg(bodyText)
         }
         htmlEmail
-      case (None, Some(bodyText)) =>
+      case (None, Some(msg)) =>
         val multiPartEmail = createMultiPartEmail()
         multiPartEmail.setCharset(charset)
-        multiPartEmail.setMsg(bodyText)
+        multiPartEmail.setMsg(msg)
         multiPartEmail
       case _ =>
         createMultiPartEmail()

--- a/user-manual.adoc
+++ b/user-manual.adoc
@@ -1,0 +1,57 @@
+= Play mailer plugin User Manual
+
+== Configure mailer instance
+
+=== Runtime Dependency Injection
+
+By default the plugin automatically configure the injected instances with the `application.conf` file:
+
+```scala
+class MyComponent @Inject() (mailer: MailerClient) {
+  // ...
+}
+```
+
+If you want to configure the injected instances from another source, you will need to override the default provider:
+
+ 1. Create a custom configuration provider:
++
+.CustomSMTPConfigurationProvider.scala
+```scala
+class CustomSMTPConfigurationProvider extends Provider[SMTPConfiguration] {
+  override def get() {
+    // Custom configuration
+    new SMTPConfiguration("typesafe.org", 1234)
+  }
+}
+
+class CustomMailerConfigurationModule extends Module {
+  def bindings(environment: Environment, configuration: Configuration) = Seq(
+    bind[SMTPConfiguration].toProvider[CustomSMTPConfigurationProvider]
+  )
+}
+```
+
+ 2. Override the default provider in the `application.conf` file:
++
+.application.conf
+```bash
+play {
+  modules {
+    # Disable the default provider
+    disabled += "play.api.libs.mailer.SMTPConfigurationModule"
+    # Enable the custom provider (see above)
+    enabled += "controllers.CustomMailerConfigurationModule"
+  }
+}
+```
+
+=== New instances
+
+You can also use the `SMTPMailer` constructor to create new instances with custom configuration:
+
+```scala
+val email = Email("Simple email", "Mister FROM <from@email.com>")
+new SMTPMailer(SMTPConfiguration("typesafe.org", 1234)).send(email)
+new SMTPMailer(SMTPConfiguration("playframework.com", 5678)).send(email)
+```


### PR DESCRIPTION
This is a proposition to replace the `configure` method.
Currently the mailer instance is mutable, when it gets reconfigured, it gets reconfigured globally.
The goal is to have an immutable mailer instance. See: https://github.com/playframework/play-mailer/issues/51#issuecomment-121798831

**Principle**
 * New module to provide a `SMTPConfiguration` from the `Configuration` object
   * This module can be overridden with `play.modules.disabled` (not sure if this the right way to do it) to provide a custom SMTPConfiguration (see samples)
 * CommonsMailer injects a SMTPConfiguration

Note: I think it would be better to rename `CommonsMailer` to `SMTPMailer` and `SMTPMailer` to `CommonsMailer`.

**Pros**
 * Immutable mailer instance
 * If the mailer configuration is wrong, we get an error at the start of the server (i.e. when Guice initializes objects) rather than when the code is executed
 * It's easy to (manually) instantiate a mailer with a custom configuration `val mailer = new CommonsMailer(SMTPConfiguration("typesafe.org", 1234))`

**Cons**
 * It's less straight forward to configure the injected instance
   * write custom module and provider + disable the default module and enable the custom module 
 * "Cryptic" error message when the mailer configuration is wrong (because Guice is unable to create a `SMTPConfiguration`)

 ```
ProvisionException: Unable to provision, see the following errors:

1) Error in custom provider, java.lang.RuntimeException: host needs to be set in order to use this plugin (or set play.mailer.mock to true in application.conf)
  while locating play.api.libs.mailer.SMTPConfigurationProvider
  while locating play.api.libs.mailer.SMTPConfiguration
    for parameter 0 at play.api.libs.mailer.CommonsMailer.<init>(MailerPlugin.scala:86)
  while locating play.api.libs.mailer.CommonsMailer
  while locating play.api.libs.mailer.MailerClient
    for parameter 0 at controllers.ApplicationJava.<init>(ApplicationJava.java:18)
  while locating controllers.ApplicationJava
    for parameter 1 at router.Routes.<init>(Routes.scala:32)
  while locating router.Routes
  while locating play.api.inject.RoutesProvider
  while locating play.api.routing.Router
Caused by: java.lang.RuntimeException: host needs to be set in order to use this plugin (or set play.mailer.mock to true in application.conf)
```
 * Not binary compatible