### PR TITLE
Sync with play master

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
 lazy val `play-mailer` = (project in file("."))
   .enablePlugins(PlayLibrary, PlayReleaseBase)
     
-val PlayVersion = playVersion("2.4.2")
+val PlayVersion = playVersion("2.5.0-SNAPSHOT")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % PlayVersion % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
 lazy val `play-mailer` = (project in file("."))
   .enablePlugins(PlayLibrary, PlayReleaseBase)
     
-val PlayVersion = playVersion("2.5.0-SNAPSHOT")
+val PlayVersion = playVersion("2.5.0+")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % PlayVersion % Provided,

--- a/src/main/scala/play/api/libs/mailer/MailerPlugin.scala
+++ b/src/main/scala/play/api/libs/mailer/MailerPlugin.scala
@@ -290,14 +290,14 @@ case class SMTPConfiguration(host: String,
 object SMTPConfiguration {
 
   def apply(config: PlayConfig) = new SMTPConfiguration(
-    config.getOptional[String]("host").getOrElse(throw new RuntimeException("host needs to be set in order to use this plugin (or set play.mailer.mock to true in application.conf)")),
+    config.get[Option[String]]("host").getOrElse(throw new RuntimeException("host needs to be set in order to use this plugin (or set play.mailer.mock to true in application.conf)")),
     config.get[Int]("port"),
     config.get[Boolean]("ssl"),
     config.get[Boolean]("tls"),
-    config.getOptional[String]("user"),
-    config.getOptional[String]("password"),
+    config.get[Option[String]]("user"),
+    config.get[Option[String]]("password"),
     config.get[Boolean]("debug"),
-    config.getOptional[Int]("timeout"),
-    config.getOptional[Int]("connectiontimeout")
+    config.get[Option[Int]]("timeout"),
+    config.get[Option[Int]]("connectiontimeout")
   )
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.2-SNAPSHOT"
+version in ThisBuild := "3.0.2-next-SNAPSHOT"


### PR DESCRIPTION
Since `getOptional[T]` was removed from play master in [this commit](https://github.com/playframework/playframework/pull/4588), anyone who builds play from source and depends on the play mailer plugin (without pulling in the play 2.4.2 dep) will have their application terminate on each and every sent email due to `NoSuchMethodError` on `getOptional[T]` o_O

Making matters worse, Akka swallows the actual cause (NSME) leaving one with a joyful stack trace [like this](http://pastebin.com/ECSP5V0P) which is about as helpful as, "error: good luck".

Anyway, this is very much an edge case, most play-ers are unaffected, but it would be nice to provide snapshot builds of plugins in future so those of us that build from source can avoid above situation.