### PR TITLE
Make Email.java usable in fluent interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ smtp.connectiontimeout (defaults to 60s)
 import play.libs.mailer.Email;
 import play.libs.mailer.MailerPlugin;
 
-Email email = new Email();
-email.setSubject("Simple email");
-email.setFrom("Mister FROM <from@email.com>");
-email.addTo("Miss TO <to@email.com>");
-// adds attachment
-email.addAttachment("attachment.pdf", new File("/some/path/attachment.pdf"));
-// adds inline attachment from byte array
-email.addAttachment("data.txt", "data".getBytes(), "text/plain", "Simple data", EmailAttachment.INLINE);
-// sends text, HTML or both...
-email.setBodyText("A text message");
-email.setBodyHtml("<html><body><p>An <b>html</b> message</p></body></html>");
+Email email = new Email()
+ .setSubject("Simple email")
+ .setFrom("Mister FROM <from@email.com>")
+ .addTo("Miss TO <to@email.com>")
+ // adds attachment
+ .addAttachment("attachment.pdf", new File("/some/path/attachment.pdf"))
+ // adds inline attachment from byte array
+ .addAttachment("data.txt", "data".getBytes(), "text/plain", "Simple data", EmailAttachment.INLINE)
+ // sends text, HTML or both...
+ .setBodyText("A text message")
+ .setBodyHtml("<html><body><p>An <b>html</b> message</p></body></html>");
 MailerPlugin.send(email);
 ```
 

--- a/src/main/scala/play/libs/mailer/Email.java
+++ b/src/main/scala/play/libs/mailer/Email.java
@@ -25,127 +25,147 @@ public class Email {
     return subject;
   }
 
-  public void setSubject(String subject) {
+  public Email setSubject(String subject) {
     this.subject = subject;
+    return this;
   }
 
   public String getFrom() {
     return from;
   }
 
-  public void setFrom(String from) {
+  public Email setFrom(String from) {
     this.from = from;
+    return this;
   }
 
   public String getBodyText() {
     return bodyText;
   }
 
-  public void setBodyText(String bodyText) {
+  public Email setBodyText(String bodyText) {
     this.bodyText = bodyText;
+    return this;
   }
 
   public String getBodyHtml() {
     return bodyHtml;
   }
 
-  public void setBodyHtml(String bodyHtml) {
+  public Email setBodyHtml(String bodyHtml) {
     this.bodyHtml = bodyHtml;
+    return this;
   }
 
-  public void addTo(String address) {
+  public Email addTo(String address) {
     this.to.add(address);
+    return this;
   }
 
   public List<String> getTo() {
     return to;
   }
 
-  public void setTo(List<String> to) {
+  public Email setTo(List<String> to) {
     this.to = to;
+    return this;
   }
 
-  public void addCc(String address) {
+  public Email addCc(String address) {
     this.cc.add(address);
+    return this;
   }
 
   public List<String> getCc() {
     return cc;
   }
 
-  public void setCc(List<String> cc) {
+  public Email setCc(List<String> cc) {
     this.cc = cc;
+    return this;
   }
 
-  public void addBcc(String address) {
+  public Email addBcc(String address) {
     this.bcc.add(address);
+    return this;
   }
 
   public List<String> getBcc() {
     return bcc;
   }
 
-  public void setBcc(List<String> bcc) {
+  public Email setBcc(List<String> bcc) {
     this.bcc = bcc;
+    return this;
   }
 
   public String getReplyTo() {
     return replyTo;
   }
 
-  public void setReplyTo(String replyTo) {
+  public Email setReplyTo(String replyTo) {
     this.replyTo = replyTo;
+    return this;
   }
 
   public String getBounceAddress() {
     return bounceAddress;
   }
 
-  public void setBounceAddress(String bounceAddress) {
+  public Email setBounceAddress(String bounceAddress) {
     this.bounceAddress = bounceAddress;
+    return this;
   }
 
-  public void addAttachment(String name, File file) {
+  public Email addAttachment(String name, File file) {
     this.attachments.add(new Attachment(name, file));
+    return this;
   }
 
-  public void addAttachment(String name, File file, String description, String disposition) {
+  public Email addAttachment(String name, File file, String description, String disposition) {
     this.attachments.add(new Attachment(name, file, description, disposition));
+    return this;
   }
 
-  public void addAttachment(String name, byte[] data, String mimeType) {
+  public Email addAttachment(String name, byte[] data, String mimeType) {
     this.attachments.add(new Attachment(name, data, mimeType));
+    return this;
   }
 
-  public void addAttachment(String name, byte[] data, String mimeType, String description, String disposition) {
+  public Email addAttachment(String name, byte[] data, String mimeType, String description, String disposition) {
     this.attachments.add(new Attachment(name, data, mimeType, description, disposition));
+    return this;
   }
 
   public List<Attachment> getAttachments() {
     return attachments;
   }
 
-  public void setAttachments(List<Attachment> attachments) {
+  public Email setAttachments(List<Attachment> attachments) {
     this.attachments = attachments;
+    return this;
   }
 
   public String getCharset() {
     return charset;
   }
 
-  public void setCharset(String charset) {
+  public Email setCharset(String charset) {
     this.charset = charset;
+    return this;
   }
 
-  public void addHeader(String key, String value) {
+  public Email addHeader(String key, String value) {
     this.headers.put(key, value);
+    return this;
   }
 
   public Map<String, String> getHeaders() {
     return headers;
   }
 
-  public void setHeaders(Map<String, String> headers) {
+  public Email setHeaders(Map<String, String> headers) {
     this.headers = headers;
+    return this;
   }
 }


### PR DESCRIPTION
Declaring an email is very verbose. Making the setters return the object, makes it easier and clearer.