### PR TITLE
Fixed broken links in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 # About
 :next-branch-uri: https://github.com/playframework/play-mailer/tree/next
-:playframework-24x-docs-uri: https://www.playframework.com/documentation/2.4.x/
+:playframework-24x-docs-uri: https://www.playframework.com/documentation/2.4.x
 :runtime-di-uri: {playframework-24x-docs-uri}/ScalaDependencyInjection
 :compile-time-di-uri: {playframework-24x-docs-uri}/ScalaCompileTimeDependencyInjection
 


### PR DESCRIPTION
Removed accidental double '/'s from play framework documentation links.