### PR TITLE
Clarified units in documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,8 +33,8 @@ play.mailer {
   user (optional)
   password (optional)
   debug (defaults to no, to take effect you also need to set the log level to "DEBUG" for the application logger)
-  timeout (defaults to 60s)
-  connectiontimeout (defaults to 60s)
+  timeout (defaults to 60s in milliseconds)
+  connectiontimeout (defaults to 60s in milliseconds)
   mock (defaults to no, will only log all the email properties instead of sending an email)
 }
 ```


### PR DESCRIPTION
Documentation is misleading. It says default timeouts are `60s`. Values are actually milliseconds. Updated documentation to note this. See [Apache Mailer Docs](https://commons.apache.org/proper/commons-email/apidocs/org/apache/commons/mail/Email.html#socketConnectionTimeout).

We just implemented this on a Play! app, only to note occasional failures because we set timeouts to 90ms, not 90s, so we were dropping connections due to a far too short timeout. I hope this clarification helps others.