### PR TITLE
match instructions with class name from example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -158,7 +158,7 @@ class ApplicationComponents(context: Context) extends BuiltInComponentsFromConte
 }
 ```
 
-Finally add this line `play.application.loader=SimpleApplicationLoader` in `application.conf`.
+Finally add this line `play.application.loader=MyApplicationLoader` in `application.conf`.
 
 ## Versioning
 


### PR DESCRIPTION
I believe the intention of the proposed `application.conf` line is to activate the `ApplicationLoader` in the example, but since the names don't match, I don't think this will work. This PR rectifies the situation.