### PR TITLE
Force TLS in Play Mailer

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,7 @@ play.mailer {
   port (defaults to 25)
   ssl (defaults to no)
   tls (defaults to no)
+  tlsRequired (defaults to no)
   user (optional)
   password (optional)
   debug (defaults to no, to take effect you also need to set the log level to "DEBUG" for the application logger)

--- a/samples/compile-timeDI/conf/application.conf
+++ b/samples/compile-timeDI/conf/application.conf
@@ -27,6 +27,7 @@ logger.application=DEBUG
 #  port=25
 #  ssl=false
 #  tls=false
+#  tlsRequired=false
 #  user=clark.kent
 #  password=superman
 #  debug=false

--- a/samples/runtimeDI/conf/application.conf
+++ b/samples/runtimeDI/conf/application.conf
@@ -27,6 +27,7 @@ logger.application=DEBUG
 #  port=25
 #  ssl=false
 #  tls=false
+#  tlsRequired=false
 #  user=clark.kent
 #  password=superman
 #  debug=false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -8,6 +8,7 @@ play {
     port = 25
     ssl = no
     tls = no
+    tlsRequired = no
     user = null
     password = null
     // Defaults to no, to take effect you also need to set the log level to "DEBUG" for the application logger

--- a/src/main/scala/play/api/libs/mailer/MailerPlugin.scala
+++ b/src/main/scala/play/api/libs/mailer/MailerPlugin.scala
@@ -154,7 +154,8 @@ abstract class CommonsMailer(conf: SMTPConfiguration) extends MailerClient {
     if (conf.ssl) {
       email.setSslSmtpPort(conf.port.toString)
     }
-    email.setStartTLSEnabled(conf.tls)
+    email.setStartTLSEnabled(conf.tls || conf.tlsRequired)
+    email.setStartTLSRequired(conf.tlsRequired)
     for (u <- conf.user; p <- conf.password) yield email.setAuthenticator(new DefaultAuthenticator(u, p))
     if (conf.debugMode && Logger.isDebugEnabled) {
       email.setDebug(conf.debugMode)
@@ -303,6 +304,7 @@ case class SMTPConfiguration(host: String,
                              port: Int,
                              ssl: Boolean = false,
                              tls: Boolean = false,
+                             tlsRequired: Boolean = false,
                              user: Option[String] = None,
                              password: Option[String] = None,
                              debugMode: Boolean = false,
@@ -317,6 +319,7 @@ object SMTPConfiguration {
     config.get[Int]("port"),
     config.get[Boolean]("ssl"),
     config.get[Boolean]("tls"),
+    config.get[Boolean]("tlsRequired"),
     config.get[Option[String]]("user"),
     config.get[Option[String]]("password"),
     config.get[Boolean]("debug"),

--- a/src/test/scala/play/api/libs/mailer/MailerPluginSpec.scala
+++ b/src/test/scala/play/api/libs/mailer/MailerPluginSpec.scala
@@ -29,7 +29,7 @@ class MailerPluginSpec extends Specification with Mockito {
   object MockCommonsMailer extends MockCommonsMailerWithTimeouts(None, None)
 
   class MockCommonsMailerWithTimeouts(smtpTimeout: Option[Int], smtpConnectionTimeout: Option[Int])
-    extends CommonsMailer(SMTPConfiguration("typesafe.org", 1234, ssl = true, tls = false, Some("user"), Some("password"), debugMode = false, smtpTimeout, smtpConnectionTimeout, mock = false)) {
+    extends CommonsMailer(SMTPConfiguration("typesafe.org", 1234, ssl = true, tls = false, tlsRequired = false, Some("user"), Some("password"), debugMode = false, smtpTimeout, smtpConnectionTimeout, mock = false)) {
     override def send(email: MultiPartEmail) = ""
     override def createMultiPartEmail(): MultiPartEmail = new MockMultiPartEmail
     override def createHtmlEmail(): HtmlEmail = new MockHtmlEmail
@@ -47,6 +47,7 @@ class MailerPluginSpec extends Specification with Mockito {
       email.getMailSession.getProperty("mail.smtp.auth") mustEqual "true"
       email.getMailSession.getProperty("mail.smtp.host") mustEqual "typesafe.org"
       email.getMailSession.getProperty("mail.smtp.starttls.enable") mustEqual "false"
+      email.getMailSession.getProperty("mail.smtp.starttls.required") mustEqual "false"
       email.getMailSession.getProperty("mail.debug") mustEqual "false"
     }
 


### PR DESCRIPTION
From the [Mailing List](https://groups.google.com/forum/#!topic/play-framework/BuepWm2p4Ok):

Currently it is not possible to ensure that a mail or a password is not send unencrypted when using the TLS option. The library will _try_ to use TLS _if_ the server supports it, but will silently fall back to unencrypted communication if the server does not. 

The new configuration option will prevent the connection from succeeding (from a application programmers point of view) if no secure TLS connection could be created.