### PR TITLE
Cannot jump to Usage section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ play.mailer {
 }
 ```
 
-If you are on Play 2.6.x you can skip to [Usage](#Usage).
+If you are on Play 2.6.x you can skip to [Usage](#usage).
 For Play 2.5.x you might also need a ConfigModule:
 
 ### Play 2.5.x and Scala


### PR DESCRIPTION
Markdown processor seems to create link with lower cased word.