### PR TITLE
Configure HELO/EHLO via config "mail.smtp.localhost"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ matrix:
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test
-  - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
+#  - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ play.mailer {
   timeout = null // (defaults to 60s in milliseconds)
   connectiontimeout = null // (defaults to 60s in milliseconds)
   mock = no // (defaults to no, will only log all the email properties instead of sending an email)
+  props {
+    // Additional SMTP properties used by JavaMail. Can override existing configuration keys from above.
+    // A given property will be set for both the "mail.smtp.*" and the "mail.smtps.*" prefix.
+    // For a list of properties see:
+    // https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html#properties
+
+    // Example:
+    // To set the local host name used in the SMTP HELO or EHLO command:
+    // localhost = 127.0.0.1
+    // Results in "mail.smtp.localhost=127.0.0.1" and "mail.smtps.localhost=127.0.0.1" in the JavaMail session.
+  }
 }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val commonSettings = mimaDefaultSettings ++ Seq(
 val PlayVersion = playVersion(sys.env.getOrElse("PLAY_VERSION", "2.6.18"))
 
 // Version used to check binary compatibility
-val mimaPreviousArtifactsVersion = "6.0.0"
+val mimaPreviousArtifactsVersion = "7.0.0"
 
 lazy val `play-mailer` = (project in file("play-mailer"))
   .enablePlugins(PlayLibrary)

--- a/play-mailer/src/main/resources/reference.conf
+++ b/play-mailer/src/main/resources/reference.conf
@@ -15,5 +15,16 @@ play {
     timeout = null
     // Set the socket connection timeout value in milliseconds. Default is a 60 second timeout.
     connectiontimeout = null
+    props {
+      // Additional SMTP properties used by JavaMail. Can override existing configuration keys from above.
+      // A given property will be set for both the "mail.smtp.*" and the "mail.smtps.*" prefix.
+      // For a list of properties see:
+      // https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html#properties
+
+      // Example:
+      // To set the local host name used in the SMTP HELO or EHLO command:
+      // localhost = 127.0.0.1
+      // Results in "mail.smtp.localhost=127.0.0.1" and "mail.smtps.localhost=127.0.0.1" in the JavaMail session.
+    }
   }
 }

--- a/play-mailer/src/main/scala/play/api/libs/mailer/SMTPConfiguration.scala
+++ b/play-mailer/src/main/scala/play/api/libs/mailer/SMTPConfiguration.scala
@@ -1,6 +1,6 @@
 package play.api.libs.mailer
 
-import com.typesafe.config.Config
+import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.util.Try
 
@@ -15,6 +15,7 @@ case class SMTPConfiguration(
     debugMode: Boolean = false,
     timeout: Option[Int] = None,
     connectionTimeout: Option[Int] = None,
+    props: Config = ConfigFactory.empty(),
     mock: Boolean = false
 )
 
@@ -41,6 +42,7 @@ object SMTPConfiguration {
     config.getBoolean("debug"),
     getOptionInt(config, "timeout"),
     getOptionInt(config, "connectiontimeout"),
+    config.getConfig("props"),
     config.getBoolean("mock")
   )
 

--- a/samples/compile-timeDI/build.sbt
+++ b/samples/compile-timeDI/build.sbt
@@ -8,7 +8,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-mailer" % "6.0.0-SNAPSHOT"
+  "com.typesafe.play" %% "play-mailer" % "7.0.0-SNAPSHOT"
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)

--- a/samples/runtimeDI/build.sbt
+++ b/samples/runtimeDI/build.sbt
@@ -8,7 +8,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-mailer" % "6.0.0-SNAPSHOT"
+  "com.typesafe.play" %% "play-mailer" % "7.0.0-SNAPSHOT"
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "6.0.2-SNAPSHOT"
+version in ThisBuild := "7.0.0-SNAPSHOT"


### PR DESCRIPTION
JavaMail tries to figure out the domain it sends with the `HELO` or `EHLO` command [by itself](https://github.com/javaee/javamail/blob/JAVAMAIL-1_6_1/mail/src/main/java/com/sun/mail/smtp/SMTPTransport.java#L286), which in most cases is correct (see [SMTP transport example](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol#SMTP_transport_example)).

However our server has multiple network interfaces and so it happened that it used a wrong address.
Therefore we need a way to configure the domain sent by the `HELO` or `EHLO` command - this can be done via the JavaMail property `mail.smtp.localhost` (see [list of properties](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html#properties) and the JavaMail [source](https://github.com/javaee/javamail/blob/JAVAMAIL-1_6_1/mail/src/main/java/com/sun/mail/smtp/SMTPTransport.java#L280)).

Commons Email does not provide helper methods to set that property, therefore we have to put that in the JavaMail session ourself.
The change I made makes it easy to set other `mail.smtp.*` properties in future (if needed).