### PR TITLE
Update to Play 2.6.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ language: scala
 
 scala:
    - 2.11.12
-   - 2.12.4
+   - 2.12.6
 
 matrix:
    include:
-      - env: PLAY_VERSION=2.5.18
+      - env: PLAY_VERSION=2.5.19
         scala: 2.11.12
 
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -4,23 +4,24 @@ import interplay.ScalaVersions
 
 import scalariform.formatter.preferences._
 
-lazy val commonSettings = mimaDefaultSettings ++ SbtScalariform.scalariformSettings ++ Seq(
+lazy val commonSettings = mimaDefaultSettings ++ Seq(
   // scalaVersion needs to be kept in sync with travis-ci
   scalaVersion := ScalaVersions.scala212,
   crossScalaVersions := Seq(ScalaVersions.scala211, ScalaVersions.scala212),
+  scalariformAutoformat := true,
   ScalariformKeys.preferences := ScalariformKeys.preferences.value
     .setPreference(SpacesAroundMultiImports, true)
     .setPreference(SpaceInsideParentheses, false)
     .setPreference(DanglingCloseParenthesis, Preserve)
     .setPreference(PreserveSpaceBeforeArguments, true)
-    .setPreference(DoubleIndentClassDeclaration, true)
+    .setPreference(DoubleIndentConstructorArguments, true)
 )
 
 // needs to be kept in sync with travis-ci
-val PlayVersion = playVersion(sys.env.getOrElse("PLAY_VERSION", "2.6.11"))
+val PlayVersion = playVersion(sys.env.getOrElse("PLAY_VERSION", "2.6.18"))
 
 // Version used to check binary compatibility
-val mimaPreviousArtifactsVersion = "6.0.0"
+val mimaPreviousArtifactsVersion = "6.0.1"
 
 lazy val `play-mailer` = (project in file("play-mailer"))
   .enablePlugins(PlayLibrary)
@@ -28,7 +29,7 @@ lazy val `play-mailer` = (project in file("play-mailer"))
   .settings(
     libraryDependencies ++= Seq(
       "javax.inject" % "javax.inject" % "1",
-      "com.typesafe" % "config" % "1.3.2",
+      "com.typesafe" % "config" % "1.3.3",
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "org.apache.commons" % "commons-email" % "1.5",
       "com.typesafe.play" %% "play" % PlayVersion % Test,
@@ -45,7 +46,7 @@ lazy val `play-mailer-guice` = (project in file("play-mailer-guice"))
   .dependsOn(`play-mailer`)
   .settings(
     libraryDependencies ++= Seq(
-      "com.google.inject" % "guice" % "4.0", // 4.0 to maybe make it work with 2.5 and 2.6
+      "com.google.inject" % "guice" % "4.1.0", // 4.1.0 to maybe make it work with 2.5 and 2.6
       "com.typesafe.play" %% "play" % PlayVersion % Test,
       "com.typesafe.play" %% "play-specs2" % PlayVersion % Test
     ),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.12"))
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.17"))
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")

--- a/samples/compile-timeDI/project/plugins.sbt
+++ b/samples/compile-timeDI/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")

--- a/samples/runtimeDI/project/plugins.sbt
+++ b/samples/runtimeDI/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")


### PR DESCRIPTION
This PR does the following:
 - Updates Play to version 2.6.18
 - Updates sbt to 0.13.17
 - Updates other shared dependencies to the same versions Play is currently using on the 2.6.x branch.