### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ install:
 script:
    - sbt ++$TRAVIS_SCALA_VERSION test mimaReportBinaryIssues
    # Test sample applications
-   - sbt publishLocal && pushd samples/compile-timeDI/ && sbt test && popd
-   - sbt publishLocal && pushd samples/runtimeDI/ && sbt test && popd
+   - sbt ++$TRAVIS_SCALA_VERSION publishLocal && pushd samples/compile-timeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
+   - sbt ++$TRAVIS_SCALA_VERSION publishLocal && pushd samples/runtimeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
 
 cache:
   directories:

--- a/samples/compile-timeDI/build.sbt
+++ b/samples/compile-timeDI/build.sbt
@@ -8,7 +8,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-mailer" % "7.0.1-SNAPSHOT",
+  "com.typesafe.play" %% "play-mailer" % "7.1.0-SNAPSHOT",
   "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.0" % Test
 )
 

--- a/samples/compile-timeDI/build.sbt
+++ b/samples/compile-timeDI/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-mailer" % "7.1.0-SNAPSHOT",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.0" % Test
+  "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0-M3" % Test
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)

--- a/samples/runtimeDI/build.sbt
+++ b/samples/runtimeDI/build.sbt
@@ -8,7 +8,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-mailer-guice" % "7.0.1-SNAPSHOT",
+  "com.typesafe.play" %% "play-mailer-guice" % "7.1.0-SNAPSHOT",
   "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.0" % Test
 )
 

--- a/samples/runtimeDI/build.sbt
+++ b/samples/runtimeDI/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-mailer-guice" % "7.1.0-SNAPSHOT",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.0" % Test
+  "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0-M3" % Test
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)


### PR DESCRIPTION
- Match dependencies in the test projects to the main project version
  https://github.com/playframework/play-mailer/blob/6117a2e417d49f13e1b3d9af20d6487227d4c808/version.sbt#L1
- Ensure that the same Scala version is used for all of the build steps
- Update scalatestplus-play to a version compatible with Scala 2.13