### PR TITLE
Default to enabling SSL check server identity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx
 script:
    - sbt ++$TRAVIS_SCALA_VERSION test mimaReportBinaryIssues
    # Test sample applications
-   - sbt publishLocal "print play-mailer/version" | tee /tmp/out.txt
+   - sbt ++$TRAVIS_SCALA_VERSION publishLocal "print play-mailer/version" | tee /tmp/out.txt
    - export PLAY_MAILER_VERSION=`tail -1 /tmp/out`
    - pushd samples/compile-timeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
    - pushd samples/runtimeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx
 script:
    - sbt ++$TRAVIS_SCALA_VERSION test mimaReportBinaryIssues
    # Test sample applications
-   - sbt ++$TRAVIS_SCALA_VERSION publishLocal && pushd samples/compile-timeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
-   - sbt ++$TRAVIS_SCALA_VERSION publishLocal && pushd samples/runtimeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
+   - export PLAY_MAILER_VERSION=`sbt publishLocal "print play-mailer/version" | tail -1`
+   - pushd samples/compile-timeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
+   - pushd samples/runtimeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx
 script:
    - sbt ++$TRAVIS_SCALA_VERSION test mimaReportBinaryIssues
    # Test sample applications
-   - export PLAY_MAILER_VERSION=`sbt publishLocal "print play-mailer/version" | tail -1`
+   - sbt publishLocal "print play-mailer/version" | tee /tmp/out.txt
+   - export PLAY_MAILER_VERSION=`tail -1 /tmp/out`
    - pushd samples/compile-timeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
    - pushd samples/runtimeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
 

--- a/play-mailer-guice/src/test/scala/play/api/libs/mailer/MailerPluginGuiceSpec.scala
+++ b/play-mailer-guice/src/test/scala/play/api/libs/mailer/MailerPluginGuiceSpec.scala
@@ -1,5 +1,6 @@
 package play.api.libs.mailer
 
+import com.typesafe.config.ConfigFactory
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import play.api.Application
@@ -49,7 +50,8 @@ class MailerPluginGuiceSpec extends Specification with Mockito {
       there was two(mockedConfigurationProvider).get()
     }
     "validate the configuration" in new WithApplication(applicationWithMoreMailerConfiguration) {
-      app.injector.instanceOf(bind[SMTPConfiguration]) must ===(SMTPConfiguration("typesafe.org", 25, user = Some("typesafe"), password = Some("typesafe")))
+      app.injector.instanceOf(bind[SMTPConfiguration]) must ===(SMTPConfiguration("typesafe.org", 25,
+        user = Some("typesafe"), password = Some("typesafe"), props = ConfigFactory.parseString("ssl.checkserveridentity=true")))
     }
   }
 }

--- a/play-mailer/src/main/resources/reference.conf
+++ b/play-mailer/src/main/resources/reference.conf
@@ -25,6 +25,9 @@ play {
       // To set the local host name used in the SMTP HELO or EHLO command:
       // localhost = 127.0.0.1
       // Results in "mail.smtp.localhost=127.0.0.1" and "mail.smtps.localhost=127.0.0.1" in the JavaMail session.
+
+      // If using SSL, we want to default to verifying that we trust the SSL certificate provided by the server.
+      ssl.checkserveridentity = true
     }
   }
 }


### PR DESCRIPTION
I've tested this locally to ensure that SSL connections fail when the certificate presented doesn't match the hostname used, and to ensure that they succeed when it does. Also I tested and verified by manual code inspection of the Java mail library that enabling this when SSL is not in use won't impact anything adversely.