### PR TITLE
Travis: introduce publish stage / drop Interplay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+version: ~> 1.0
+
 language: scala
 
 scala:
@@ -21,6 +23,22 @@ script:
    - export PLAY_MAILER_VERSION=`tail -1 /tmp/out`
    - pushd samples/compile-timeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
    - pushd samples/runtimeDI/ && sbt ++$TRAVIS_SCALA_VERSION test && popd
+
+jobs:
+  include:
+    - stage: check
+
+    - stage: publish
+      name: "TEMP Publish artifacts to Bintray"
+      script: sbt +mimaReportBinaryIssues
+      scala: 2.13.1
+      env: TRAVIS_JDK=11
+
+stages:
+  - name: check
+
+  - name: publish
+#    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ script:
 
 jobs:
   include:
-    - stage: check
-
     - stage: publish
       name: "TEMP Publish artifacts to Bintray"
       script: sbt +mimaReportBinaryIssues
@@ -35,8 +33,6 @@ jobs:
       env: TRAVIS_JDK=11
 
 stages:
-  - name: check
-
   - name: publish
 #    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
 stages:
   - name: test
   - name: deploy
-#    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
 stages:
   - name: test
   - name: deploy
-    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+#    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,14 @@ script:
 
 jobs:
   include:
-    - stage: publish
+    - stage: deploy
       name: "TEMP Publish artifacts to Bintray"
       script: sbt +mimaReportBinaryIssues
       scala: 2.13.1
       env: TRAVIS_JDK=11
 
 stages:
+  - name: test
   - name: publish
 #    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ jobs:
 
 stages:
   - name: test
-  - name: publish
-#    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+  - name: deploy
+    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ version: ~> 1.0
 language: scala
 
 scala:
-  - 2.12.10
-  - 2.13.1
+  - 2.12.11
+  - 2.13.2
 
 git:
   depth: false # Avoid sbt-dynver not seeing the tag
@@ -29,7 +29,7 @@ jobs:
     - stage: deploy
       name: "TEMP Publish artifacts to Bintray"
       script: sbt +mimaReportBinaryIssues
-      scala: 2.13.1
+      scala: 2.13.2
       env: TRAVIS_JDK=11
 
 stages:

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val `play-mailer-guice` = (project in file("play-mailer-guice"))
   )
 
 lazy val `play-mailer-root` = (project in file("."))
+  .disablePlugins(MimaPlugin)
   .settings(commonSettings)
   .settings(
     crossScalaVersions := Nil,

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,12 @@
 import com.typesafe.sbt.SbtScalariform._
 import com.typesafe.tools.mima.plugin.MimaPlugin._
-import interplay.ScalaVersions
 import scalariform.formatter.preferences._
 
 ThisBuild / dynverVTagPrefix := false
 
 lazy val commonSettings = mimaDefaultSettings ++ Seq(
-  // scalaVersion needs to be kept in sync with travis-ci
-  scalaVersion := ScalaVersions.scala213,
-  crossScalaVersions := Seq(ScalaVersions.scala212, ScalaVersions.scala213),
+  scalaVersion := Dependencies.Scala213,
+  crossScalaVersions := Dependencies.ScalaVersions,
   scalariformAutoformat := true,
   ScalariformKeys.preferences := ScalariformKeys.preferences.value
     .setPreference(SpacesAroundMultiImports, true)
@@ -35,19 +33,10 @@ lazy val commonSettings = mimaDefaultSettings ++ Seq(
     "-Xlint:unchecked",
     "-Xlint:deprecation"
   ),
-
-  mimaBinaryIssueFilters ++= Seq(
-  )
 )
 
-// needs to be kept in sync with travis-ci
-val PlayVersion = playVersion(sys.env.getOrElse("PLAY_VERSION", "2.8.0"))
-
-// Version used to check binary compatibility
-val mimaPreviousArtifactsVersion = "7.0.1"
-
 lazy val `play-mailer` = (project in file("play-mailer"))
-  .enablePlugins(PlayLibrary)
+  .enablePlugins(Common)
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
@@ -55,29 +44,30 @@ lazy val `play-mailer` = (project in file("play-mailer"))
       "com.typesafe" % "config" % "1.4.0",
       "org.slf4j" % "slf4j-api" % "1.7.30",
       "org.apache.commons" % "commons-email" % "1.5",
-      "com.typesafe.play" %% "play" % PlayVersion % Test,
-      "com.typesafe.play" %% "play-specs2" % PlayVersion % Test
+      "com.typesafe.play" %% "play" % Dependencies.PlayVersion % Test,
+      "com.typesafe.play" %% "play-specs2" % Dependencies.PlayVersion % Test
     ),
-    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-mailer" % mimaPreviousArtifactsVersion)
+    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-mailer" % previousStableVersion.value.get)
   )
 
 lazy val `play-mailer-guice` = (project in file("play-mailer-guice"))
-  .enablePlugins(PlayLibrary)
+  .enablePlugins(Common)
   .settings(commonSettings)
   .dependsOn(`play-mailer`)
   .settings(
     libraryDependencies ++= Seq(
       "com.google.inject" % "guice" % "4.2.2",
-      "com.typesafe.play" %% "play" % PlayVersion % Test,
-      "com.typesafe.play" %% "play-specs2" % PlayVersion % Test
+      "com.typesafe.play" %% "play" % Dependencies.PlayVersion % Test,
+      "com.typesafe.play" %% "play-specs2" % Dependencies.PlayVersion % Test
     ),
-    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-mailer-guice" % mimaPreviousArtifactsVersion)
+    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-mailer-guice" % previousStableVersion.value.get)
   )
 
 lazy val `play-mailer-root` = (project in file("."))
-  .enablePlugins(PlayRootProject, PlayReleaseBase)
   .settings(commonSettings)
-  .settings(mimaFailOnNoPrevious := false)
+  .settings(
+    crossScalaVersions := Nil,
+    publish / skip := true
+  )
   .aggregate(`play-mailer`, `play-mailer-guice`)
 
-playBuildRepoName in ThisBuild := "play-mailer"

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,9 @@
 import com.typesafe.sbt.SbtScalariform._
-import com.typesafe.tools.mima.plugin.MimaPlugin._
 import scalariform.formatter.preferences._
 
 ThisBuild / dynverVTagPrefix := false
 
-lazy val commonSettings = mimaDefaultSettings ++ Seq(
+lazy val commonSettings = Seq(
   scalaVersion := Dependencies.Scala213,
   crossScalaVersions := Dependencies.ScalaVersions,
   scalariformAutoformat := true,
@@ -47,7 +46,8 @@ lazy val `play-mailer` = (project in file("play-mailer"))
       "com.typesafe.play" %% "play" % Dependencies.PlayVersion % Test,
       "com.typesafe.play" %% "play-specs2" % Dependencies.PlayVersion % Test
     ),
-    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-mailer" % previousStableVersion.value.get)
+    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-mailer" % previousStableVersion.value
+      .getOrElse(throw new Error("Unable to determine previous version")))
   )
 
 lazy val `play-mailer-guice` = (project in file("play-mailer-guice"))
@@ -60,7 +60,8 @@ lazy val `play-mailer-guice` = (project in file("play-mailer-guice"))
       "com.typesafe.play" %% "play" % Dependencies.PlayVersion % Test,
       "com.typesafe.play" %% "play-specs2" % Dependencies.PlayVersion % Test
     ),
-    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-mailer-guice" % previousStableVersion.value.get)
+    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-mailer-guice" % previousStableVersion.value
+      .getOrElse(throw new Error("Unable to determine previous version")))
   )
 
 lazy val `play-mailer-root` = (project in file("."))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,0 +1,30 @@
+import sbt.Keys._
+import sbt._
+import sbt.plugins.JvmPlugin
+
+object Common extends AutoPlugin {
+  override def trigger = allRequirements
+
+  override def requires = JvmPlugin
+
+  val repoName = "play-mailer"
+
+  override def globalSettings =
+    Seq(
+      organization := "com.typesafe.play",
+      organizationName := "Lightbend Inc.",
+      organizationHomepage := Some(url("https://www.lightbend.com/")),
+      homepage := Some(url(s"https://github.com/playframework/${repoName}")),
+      licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
+
+      scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-encoding", "utf8"),
+      javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
+
+      scmInfo := Some(ScmInfo(url(s"https://github.com/playframework/${repoName}"), s"scm:git:git@github.com:playframework/${repoName}.git")),
+      developers += Developer("contributors",
+        "Contributors",
+        "https://gitter.im/playframework/contributors",
+        url("https://github.com/playframework")),
+
+      description := "Play mailer plugin")
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,10 @@
+import sbt._
+
+object Dependencies {
+  // scalaVersion needs to be kept in sync with travis-ci
+  val Scala212 = "2.12.11"
+  val Scala213 = "2.13.2"
+  val ScalaVersions = Seq(Scala212, Scala213)
+
+  val PlayVersion = sys.props.getOrElse("play.version", sys.env.getOrElse("PLAY_VERSION", "2.8.0"))
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "2.1.4"))
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")


### PR DESCRIPTION
Use Travis stages in preparation to publish from Travis to Bintray.

Drop the Interplay sbt plugin and do the same stuff locally instead.