### PR TITLE
Streaming attachments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ version: ~> 1.0
 language: scala
 
 scala:
-  - 2.12.11
-  - 2.13.2
+  - 2.12.13
+  - 2.13.5
 
 git:
   depth: false # Avoid sbt-dynver not seeing the tag
@@ -30,7 +30,7 @@ jobs:
     - stage: deploy
       name: "Publish artifacts to Bintray"
       script: sbt +publish
-      scala: 2.13.2
+      scala: 2.13.5
       env:
       - TRAVIS_JDK=11
         # encrypt with: travis encrypt --pro BINTRAY_USER=...

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,15 @@ env:
   - TRAVIS_JDK=11
 
 
-before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
-install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
+before_install:
+  - |
+    curl -Ls https://git.io/sbt -o sbt || travis_terminate 1
+    chmod 0755 sbt || travis_terminate 1
+    sudo mv sbt /usr/local/bin/sbt || travis_terminate 1
+  - curl --version # for debug purpose
+  - if [ ! -f ~/.jabba/jabba.sh ]; then curl -L -v --retry 5 -o jabba-install.sh https://git.io/jabba && bash jabba-install.sh; fi
+  - . ~/.jabba/jabba.sh
+install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=patch) && jabba use "$_" && java -Xmx32m -version
 
 script:
    - sbt ++$TRAVIS_SCALA_VERSION test mimaReportBinaryIssues
@@ -45,9 +52,9 @@ stages:
 
 cache:
   directories:
-    - $HOME/.coursier/cache
-    - $HOME/.ivy2
-    - $HOME/.jabba/jdk
+    - $HOME/.cache/coursier
+    - $HOME/.ivy2/cache
+    - $HOME/.jabba
     - $HOME/.sbt
 
 before_cache:

--- a/play-mailer/src/main/java/play/libs/mailer/Attachment.java
+++ b/play-mailer/src/main/java/play/libs/mailer/Attachment.java
@@ -1,6 +1,8 @@
 package play.libs.mailer;
 
+import javax.activation.DataSource;
 import java.io.File;
+import java.net.URL;
 
 public class Attachment {
 
@@ -9,6 +11,8 @@ public class Attachment {
   private String description;
   private String disposition;
   private byte[] data;
+  private DataSource dataSource;
+  private URL url;
   private String mimetype;
   private String contentId;
 
@@ -56,6 +60,42 @@ public class Attachment {
     this.disposition = disposition;
   }
 
+  public Attachment(String name, DataSource dataSource) {
+    this.name = name;
+    this.dataSource = dataSource;
+  }
+
+  public Attachment(String name, DataSource dataSource, String contentId) {
+    this.name = name;
+    this.dataSource = dataSource;
+    this.contentId = contentId;
+  }
+
+  public Attachment(String name, DataSource dataSource, String description, String disposition) {
+    this.name = name;
+    this.dataSource = dataSource;
+    this.description = description;
+    this.disposition = disposition;
+  }
+
+  public Attachment(String name, URL url) {
+    this.name = name;
+    this.url = url;
+  }
+
+  public Attachment(String name, URL url, String contentId) {
+    this.name = name;
+    this.url = url;
+    this.contentId = contentId;
+  }
+
+  public Attachment(String name, URL url, String description, String disposition) {
+    this.name = name;
+    this.url = url;
+    this.description = description;
+    this.disposition = disposition;
+  }
+
   public String getName() {
     return name;
   }
@@ -94,6 +134,22 @@ public class Attachment {
 
   public void setData(byte[] data) {
     this.data = data;
+  }
+
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public URL getUrl() {
+    return url;
+  }
+
+  public void setUrl(URL url) {
+    this.url = url;
   }
 
   public String getMimetype() {

--- a/play-mailer/src/main/java/play/libs/mailer/Email.java
+++ b/play-mailer/src/main/java/play/libs/mailer/Email.java
@@ -1,6 +1,8 @@
 package play.libs.mailer;
 
+import javax.activation.DataSource;
 import java.io.File;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -149,6 +151,36 @@ public class Email {
 
   public Email addAttachment(String name, byte[] data, String mimeType, String description, String disposition) {
     this.attachments.add(new Attachment(name, data, mimeType, description, disposition));
+    return this;
+  }
+
+  public Email addAttachment(String name, DataSource dataSource) {
+    this.attachments.add(new Attachment(name, dataSource));
+    return this;
+  }
+
+  public Email addAttachment(String name, DataSource dataSource, String contentId) {
+    this.attachments.add(new Attachment(name, dataSource, contentId));
+    return this;
+  }
+
+  public Email addAttachment(String name, DataSource dataSource, String description, String disposition) {
+    this.attachments.add(new Attachment(name, dataSource, description, disposition));
+    return this;
+  }
+
+  public Email addAttachment(String name, URL url) {
+    this.attachments.add(new Attachment(name, url));
+    return this;
+  }
+
+  public Email addAttachment(String name, URL url, String contentId) {
+    this.attachments.add(new Attachment(name, url, contentId));
+    return this;
+  }
+
+  public Email addAttachment(String name, URL url, String description, String disposition) {
+    this.attachments.add(new Attachment(name, url, description, disposition));
     return this;
   }
 

--- a/play-mailer/src/main/scala/play/api/libs/mailer/Attachment.scala
+++ b/play-mailer/src/main/scala/play/api/libs/mailer/Attachment.scala
@@ -1,6 +1,8 @@
 package play.api.libs.mailer
 
 import java.io.File
+import java.net.URL
+import javax.activation.DataSource
 
 sealed trait Attachment
 
@@ -16,6 +18,22 @@ case class AttachmentData(
 case class AttachmentFile(
     name: String,
     file: File,
+    description: Option[String] = None,
+    disposition: Option[String] = None,
+    contentId: Option[String] = None
+) extends Attachment
+
+case class AttachmentDataSource(
+    name: String,
+    dataSource: DataSource,
+    description: Option[String] = None,
+    disposition: Option[String] = None,
+    contentId: Option[String] = None
+) extends Attachment
+
+case class AttachmentURL(
+    name: String,
+    url: URL,
     description: Option[String] = None,
     disposition: Option[String] = None,
     contentId: Option[String] = None

--- a/play-mailer/src/main/scala/play/api/libs/mailer/MailerClient.scala
+++ b/play-mailer/src/main/scala/play/api/libs/mailer/MailerClient.scala
@@ -26,11 +26,21 @@ trait MailerClient extends JMailerClient {
           attachment.getName,
           attachment.getFile,
           Option(attachment.getDescription), Option(attachment.getDisposition), Option(attachment.getContentId))
-      } else {
+      } else if (Option(attachment.getData).isDefined) {
         AttachmentData(
           attachment.getName,
           attachment.getData,
           attachment.getMimetype,
+          Option(attachment.getDescription), Option(attachment.getDisposition), Option(attachment.getContentId))
+      } else if (Option(attachment.getDataSource).isDefined) {
+        AttachmentDataSource(
+          attachment.getName,
+          attachment.getDataSource,
+          Option(attachment.getDescription), Option(attachment.getDisposition), Option(attachment.getContentId))
+      } else {
+        AttachmentURL(
+          attachment.getName,
+          attachment.getUrl,
           Option(attachment.getDescription), Option(attachment.getDisposition), Option(attachment.getContentId))
       }
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
   // scalaVersion needs to be kept in sync with travis-ci
-  val Scala212 = "2.12.11"
-  val Scala213 = "2.13.2"
+  val Scala212 = "2.12.13"
+  val Scala213 = "2.13.5"
   val ScalaVersions = Seq(Scala212, Scala213)
 
   val PlayVersion = sys.props.getOrElse("play.version", sys.env.getOrElse("PLAY_VERSION", "2.8.0"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.5
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 // Even in samples projects

--- a/samples/compile-timeDI/build.sbt
+++ b/samples/compile-timeDI/build.sbt
@@ -5,9 +5,9 @@ name := "compile-time-DI"
 
 ThisBuild / dynverVTagPrefix := false
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.5"
 
-crossScalaVersions := Seq("2.12.10", "2.13.1")
+crossScalaVersions := Seq("2.12.13", "2.13.5")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-mailer" % version.value,

--- a/samples/compile-timeDI/project/build.properties
+++ b/samples/compile-timeDI/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.13

--- a/samples/runtimeDI/build.sbt
+++ b/samples/runtimeDI/build.sbt
@@ -5,9 +5,9 @@ name := "runtime-DI"
 
 ThisBuild / dynverVTagPrefix := false
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.5"
 
-crossScalaVersions := Seq("2.12.10", "2.13.1")
+crossScalaVersions := Seq("2.12.13", "2.13.5")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-mailer-guice" % version.value,

--- a/samples/runtimeDI/project/build.properties
+++ b/samples/runtimeDI/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.13


### PR DESCRIPTION
Fixes #192

Actually this was quite easy because the `MultiPartEmail` class already [has `attach(...)` methods](https://commons.apache.org/proper/commons-email/javadocs/api-release/org/apache/commons/mail/MultiPartEmail.html#method.summary) that handle `DataSource` and `URL` objects.

With this new methods it's more comfortable to stream data (instead of using a workaround like [here](https://github.com/playframework/play-mailer/issues/192#issuecomment-706756315)). Helps when e.g. attachments are stored in S3 buckets, using alpakka's S3 connector for example.

Simple example with the Java API:
```java
  final Source<ByteString, NotUsed> source = ...
  final DataSource dataSource = new DataSource() {
    @Override
    public InputStream getInputStream() throws IOException {
      return source.runWith(StreamConverters.asInputStream(), Materializer.matFromSystem(actorSystem));
    }

    @Override
    public OutputStream getOutputStream() throws IOException {
      throw new IOException("cannot do this"); // Should never happen, no need for an OutputStream
    }

    @Override
    public String getContentType() {
      return "application/pdf";
    }

    @Override
    public String getName() {
      return "contract.pdf";
    }
  };

  Email email = new Email()
      ...
      .addAttachment("contract.pdf", dataSource, "New awesome Contract", EmailAttachment.ATTACHMENT)
      ...
  this.mailerClient.send(email);
```