### PR TITLE
Group Scala Steward patch updates into single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,11 @@
+pullRequests.frequency = "@monthly"
+
+commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] }
+]
+
 buildRoots = [
   ".",
   "samples/compile-timeDI",


### PR DESCRIPTION
Patch updates are likey to not break anything so we can just put them into one PR.