### PR TITLE
"Correct" dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,10 +1,8 @@
 name: Dependency Graph
 on:
-  workflow_run:
-    workflows: ["Check"]
-    branches: [main]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
@@ -18,7 +16,6 @@ jobs:
   dependency-graph:
     name: Submit dependencies to GitHub
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Seems while https://github.com/scalacenter/sbt-dependency-submission/issues/84 was in progress I submitted #252 which I never reverted.
I mean it's ok, it works, but I quickly diffed all `.github/workflows/dependency-graph.yml` files of all our projects and they are all the same except this one.